### PR TITLE
Typo in DoctrineORM Many-To-One

### DIFF
--- a/_includes/doctrine2/elements/association/xml/manytooneowner_as.md
+++ b/_includes/doctrine2/elements/association/xml/manytooneowner_as.md
@@ -8,8 +8,8 @@
    orphan-removal="true">
     <join-columns>
 	  <join-column 
-	   name="publisherId" 
-	   referenced-column-name="publisher_id" 
+	   name="publisher_id" 
+	   referenced-column-name="id" 
 	   nullable="false" 
 	   column-definition="itemRecord_publisherId" 
 	   on-delete="CASCADE" 


### PR DESCRIPTION
Unless I miss something, it seems there is a typo in [DoctrineORM Many-To-One](http://ormcheatsheet.com/#association). According to the [Doctrine documentation](http://doctrine-orm.readthedocs.org/en/latest/reference/association-mapping.html#one-to-many-bidirectional)

![UML](http://ormcheatsheet.com/images/elements/manytooneowner.png)

Keep up the good work
