### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ contact:
 developers@ormcheatsheet.com
 
 
-####include section
+#### include section
 
 `{% include section.html %}` parameters:
 
@@ -22,7 +22,7 @@ developers@ormcheatsheet.com
 - file - must be valid file name in *.md
 - usedtabs - specifies which tabs will be displayed, string, recognized contents: 'xml'; 'yml'; 'php'; 'more'; 'links'
 
-####tab file structure:
+#### tab file structure:
 
 allways loaded (file must exist for page to build)
 
@@ -44,7 +44,7 @@ rootdir\element\xml\file
 - to add new tab simply create the directory structure and edit the 'usedtabs' for appropriate section
 - to add new image, specify the 'imgsource/imgfile' for appropriate section
 
-####header/variable structure:
+#### header/variable structure:
 
 ~~~html
 <h1>Top level</h1>

--- a/_includes/doctrine/getting-started/basic-use/db_model.md
+++ b/_includes/doctrine/getting-started/basic-use/db_model.md
@@ -43,7 +43,7 @@ $manager->setAttribute(Doctrine_Core::ATTR_AUTO_ACCESSOR_OVERRIDE, true);
 ~~~
 Now when you try and set a users password it will be md5 encrypted. 
 
-###Autoload models from directory
+### Autoload models from directory
 
 ~~~php
 // bootstrap.php

--- a/_includes/doctrine/getting-started/installation/implementation.md
+++ b/_includes/doctrine/getting-started/installation/implementation.md
@@ -1,4 +1,4 @@
-###Include Doctrine libraries
+### Include Doctrine libraries
 
 Find the `Doctrine.php` file containing the core class in the lib folder where you downloaded Doctrine.
 
@@ -34,7 +34,7 @@ When you do SVN update you will get the Doctrine libraries updated:
 svn update lib/vendor
 ~~~
 
-###Require Doctrine Base Class
+### Require Doctrine Base Class
 
 Create a file named `bootstrap.php` and place the following code in the file:
 
@@ -46,7 +46,7 @@ Create a file named `bootstrap.php` and place the following code in the file:
 require_once(dirname(**FILE**) . '/lib/vendor/doctrine/Doctrine.php');
 ~~~
 
-###Register Autoloader
+### Register Autoloader
 
 Register the class <code>:php:class:`Doctrine`</code> autoloader function in the bootstrap file:
 

--- a/_includes/doctrine/getting-started/installation/install-svn.md
+++ b/_includes/doctrine/getting-started/installation/install-svn.md
@@ -12,7 +12,7 @@ To update Doctrine execute the following command from your terminal:
 svn update
 ~~~
 
-###SVN Externals
+### SVN Externals
 
 Navigating to your checked out project:
 

--- a/_includes/doctrine/getting-started/symfony/symfonybasics.md
+++ b/_includes/doctrine/getting-started/symfony/symfonybasics.md
@@ -1,4 +1,4 @@
-####Writing Data Fixtures
+#### Writing Data Fixtures
 
 The times of using YAML for data fixtures is no longer. Instead, you are only required to use plain PHP for loading your data fixtures.
 
@@ -12,7 +12,7 @@ $admin->username = 'admin';
 $admin->password = 'changeme';
 ~~~
 
-####Building Doctrine
+#### Building Doctrine
 
 Now you're ready to build everything. The following command will build models, forms, filters, database and load data fixtures.
 
@@ -20,7 +20,7 @@ Now you're ready to build everything. The following command will build models, f
 $ php symfony doctrine:build --all --and-load
 ~~~
 
-####Updating Schema
+#### Updating Schema
 
 If you change your schema mapping information and want to update the database you can easily do so by running the following command after changing your mapping information.
 

--- a/_includes/doctrine/getting-started/symfony/symfonyinstall.md
+++ b/_includes/doctrine/getting-started/symfony/symfonyinstall.md
@@ -16,7 +16,7 @@ Add the following snippets to "deps" files:
         target=/bundles/Doctrine/Bundle/DoctrineBundle
 ~~~
 
-####Composer
+#### Composer
 
 Add the following dependencies to your projects composer.json file:
 

--- a/_includes/doctrine2/getting-started/symfony/symfonybasics.md
+++ b/_includes/doctrine2/getting-started/symfony/symfonybasics.md
@@ -1,4 +1,4 @@
-####Writing Data Fixtures
+#### Writing Data Fixtures
 
 The times of using YAML for data fixtures is no longer. Instead, you are only required to use plain PHP for loading your data fixtures.
 
@@ -12,7 +12,7 @@ $admin->username = 'admin';
 $admin->password = 'changeme';
 ~~~
 
-####Building Doctrine
+#### Building Doctrine
 
 Now you're ready to build everything. The following command will build models, forms, filters, database and load data fixtures.
 
@@ -20,7 +20,7 @@ Now you're ready to build everything. The following command will build models, f
 $ php symfony doctrine:build --all --and-load
 ~~~
 
-####Updating Schema
+#### Updating Schema
 
 If you change your schema mapping information and want to update the database you can easily do so by running the following command after changing your mapping information.
 

--- a/_includes/doctrine2/getting-started/symfony/symfonyconfig.md
+++ b/_includes/doctrine2/getting-started/symfony/symfonyconfig.md
@@ -12,7 +12,7 @@ all:
         dbname: doctrine
 ~~~
 
-####Configure Your Schema
+#### Configure Your Schema
 
 Below is an example of a simple User entity:
 

--- a/_includes/propel/getting-started/install.md
+++ b/_includes/propel/getting-started/install.md
@@ -1,4 +1,4 @@
-####Composer
+#### Composer
 
 Create a new `composer.json` file at the root of your project's directory:
 
@@ -24,7 +24,7 @@ Install dependencies:
 $ php composer.phar install
 ~~~
 
-####Git
+#### Git
 
 ~~~
 $ git clone git://github.com/propelorm/Propel2 vendor/propel
@@ -37,7 +37,7 @@ $ cd myproject/vendor/propel
 $ git pull
 ~~~
 
-####Tarball
+#### Tarball
 
 ~~~
 $ cd myproject/vendor

--- a/_includes/propel/getting-started/model_db.md
+++ b/_includes/propel/getting-started/model_db.md
@@ -1,4 +1,4 @@
-####Set Up Build Configuration
+#### Set Up Build Configuration
 
 Propel expects the build configuration to be stored in a file called `build.properties`, and stored at the same level as the `schema.xml`. Here is an example for a MySQL database:
 
@@ -10,14 +10,14 @@ propel.database = mysql
 propel.project = MyProject
 ~~~
 
-####Use the propel Script To Build The SQL Code
+#### Use the propel Script To Build The SQL Code
 
 ~~~
 $ cd /path/to/my/project
 $ propel sql:build
 ~~~
 
-####Generate Model Classes
+#### Generate Model Classes
 
 ~~~
 $ propel model:build

--- a/_includes/propel/getting-started/symfony2basics.md
+++ b/_includes/propel/getting-started/symfony2basics.md
@@ -1,4 +1,4 @@
-####Database manipulation
+#### Database manipulation
 
 Create a database:
 
@@ -12,7 +12,7 @@ Drop a database:
 > php app/console propel:database:drop [--connection[=""]] [--force]
 ~~~
 
-####Migrations
+#### Migrations
 
 Generates SQL diff between the XML schemas and the current database structure:
 
@@ -44,7 +44,7 @@ Lists the migrations yet to be executed:
 > php app/console propel:migration:status
 ~~~
 
-####Table Manipulations
+#### Table Manipulations
 
 You can drop one or several tables:
 
@@ -52,7 +52,7 @@ You can drop one or several tables:
 > php app/console propel:table:drop [--force] [--connection[="..."]] [table1] ... [tableN]
 ~~~
 
-####Working with existing databases
+#### Working with existing databases
 
 Run the following command to generate an XML schema from your default database:
 
@@ -68,7 +68,7 @@ You can define which connection to use:
 
 This will create your schema file under `app/propel/generated-schemas`. 
 
-####The Fixtures
+#### The Fixtures
 
 Loading Fixtures:
 

--- a/_includes/propel/getting-started/symfony2config.md
+++ b/_includes/propel/getting-started/symfony2config.md
@@ -1,4 +1,4 @@
-####Symfony configuration
+#### Symfony configuration
 
 In order to use Propel configure few parameters in `app/config/config.yml` file.
 
@@ -11,7 +11,7 @@ propel:
     phing_path: "%kernel.root_dir%/../vendor/phing"
 ~~~
 
-####Basic Configuration
+#### Basic Configuration
 
 If you have just one database connection, use of this parameters is recommended:
 
@@ -30,7 +30,7 @@ propel:
 
 More details can be found in [Propel documentation]()
 
-####Attributes, Options, Settings
+#### Attributes, Options, Settings
 
 ~~~yaml
 # app/config/config*.yml
@@ -49,7 +49,7 @@ propel:
                     queries:        { query: "INSERT INTO BAR ('hey', 'there')" }
 ~~~
 
-####Logging
+#### Logging
 
 ~~~yaml
 # in app/config/config.yml
@@ -57,7 +57,7 @@ propel:
     logging:    %kernel.debug%
 ~~~
 
-####Propel Configuration
+#### Propel Configuration
 
 You can add a `app/config/propel.ini` file in your project to specify some configuration parameters.
 

--- a/_includes/propel/getting-started/symfony2install.md
+++ b/_includes/propel/getting-started/symfony2install.md
@@ -1,4 +1,4 @@
-####Composer (recommended):
+#### Composer (recommended):
 
 ~~~json
 {
@@ -12,7 +12,7 @@ Tip
 
 Different bundle version may be needed for different Symfony2 version. Check PropelBundle for details.
 
-####Git, SVN, Git submodules, or the Symfony vendor management (deps file):
+#### Git, SVN, Git submodules, or the Symfony vendor management (deps file):
 
 Clone this bundle in the `vendor/bundles/Propel` directory:
 
@@ -39,7 +39,7 @@ Instead of using svn, you can clone the unofficial Git repositories:
 
 Instead of doing this manually, you can use the Symfony vendor management via the deps file. If you are using a Symfony2 2.x.x version (actually, a version which is not 2.1 or above), be sure to deps.lock the PropelBundle to a commit on the 2.0 branch, which does not use the Bridge
 
-###Bundle registration
+### Bundle registration
 
 ~~~php
 <?php


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
